### PR TITLE
Add psycopg2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py
 tomlkit
+psycopg2


### PR DESCRIPTION
You could just install it yourself but for virtenv's like pycharm it's necessary.
